### PR TITLE
Fixed compilation of version 1.3.21.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,21 @@ buildscript {
     repositories {
         jcenter()
     }
-    
+
     dependencies {
+        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }
-
+apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'kotlin'
 
 repositories {
-	maven { url 'https://minecraft.curseforge.com/api/maven/' }
+    maven { url 'https://minecraft.curseforge.com/api/maven/' }
 }
 
 dependencies {
-	compile "kottle:Kottle:$kottleVersion"
+    compile "kottle:Kottle:$kottleVersion"
 }
 ```
 , in your `gradle.properties`:
@@ -35,13 +36,37 @@ dependencies {
 # This is your kotlin gradle plugin version. For now, use 1.3.11.
 kotlinVersion = 1.3.11
 
-# For now, use 1.0.3. 
-kottleVersion = 1.0.3
+# For now, use 1.0.4.
+kottleVersion = 1.0.4
 ```
 , in your `mods.toml`:
 ```toml
 modLoader="kotlinfml"
 loaderVersion="[1,)"
+```
+
+if you prefer using version 1.3.21, in your `build.gradle`:
+```groovy
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        classpath(group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true) {
+            exclude group: 'trove', module: 'trove'
+        }
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+    }
+}
+```
+, in your `gradle.properties`
+```
+# This is your kotlin gradle plugin version. For now, use 1.3.21.
+kotlinVersion = 1.3.21
+
+# For now, use 1.0.4.
+kottleVersion = 1.0.4
 ```
 
 Then download Kottle from [here](https://minecraft.curseforge.com/projects/kottle/files) and drop it into your `run/mods`

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,9 @@ buildscript {
         maven { url 'https://files.minecraftforge.net/maven' }
     }
     dependencies {
-        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true
+        classpath(group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true) {
+            exclude group: 'trove', module: 'trove'
+        }
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }
@@ -83,14 +85,14 @@ jar {
         attributes([
                 'FMLModType': 'LANGPROVIDER'
         ])
-        
+
         attributes([
-                'Specification-Title': 'Mod Language Provider',
-                'Specification-Vendor': 'Forge Development LLC',
-                'Specification-Version': '1',
-                'Implementation-Title': archivesBaseName,
-                'Implementation-Version': version,
-                'Implementation-Vendor': 'kottle',
+                'Specification-Title'     : 'Mod Language Provider',
+                'Specification-Vendor'    : 'Forge Development LLC',
+                'Specification-Version'   : '1',
+                'Implementation-Title'    : archivesBaseName,
+                'Implementation-Version'  : version,
+                'Implementation-Vendor'   : 'kottle',
                 'Implementation-Timestamp': new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
         ], 'net/alexwells/kottle/')
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@ version = 1.0.4
 
 mappingsChannel = snapshot
 mappingsVersion = 20190215-1.13.1
-forgeVersion = net.minecraftforge:forge:1.13.2-25.0.34
+forgeVersion = net.minecraftforge:forge:1.13.2-25.0.44
 
-kotlinVersion = 1.3.11
-annotationsVersion = 16.0.3
-coroutinesVersion = 1.0.1
+kotlinVersion = 1.3.21
+annotationsVersion = 17.0.0
+coroutinesVersion = 1.1.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Feb 20 16:41:35 CST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip


### PR DESCRIPTION
This fixed the problem:
```
Execution failed for task ':compileKotlin'.
> CANONICAL
```
The reason is that,
1. ForgeGradle depends on javaxdelta, which depends on trove:trove:1.0.2(trove)
2. kotlin-gradle-plugin depends on kotlin-compiler-embeddable, which depends on org.jetbrains.intellij.deps:trove4j:1.0.20181211(trove4j).
In the package trove4j, interface TObjectHashingStrategy has two static field, IDENTITY and CANONICAL, but in trove, they didn't exist.
In version 1.3.11, the package trove4j was shaded into kotlin-compiler-embeddable with another name, so they don't have any conflict.
But in version 1.3.21, it was marked as a separate dependency, then the two library was conflicted.
When compiling kotlin, kotlin-compiler-embeddable mistakenly used trove, and it did not found CANONICAL, and caused crash of compiler.
Fixing it is also simple, just exclude trove in ForgeGradle.
Sorry for my poor English :)