### PR TITLE
Correct JVM signature used for annotation return type

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,11 +3,11 @@
 org.gradle.jvmargs=-Xmx1G
 org.gradle.daemon=false
 
-version = 1.0.5
+version = 1.0.6
 
 mappingsChannel = snapshot
 mappingsVersion = 20190215-1.13.1
-forgeVersion = net.minecraftforge:forge:1.13.2-25.0.44
+forgeVersion = net.minecraftforge:forge:1.13.2-25.0.64
 
 kotlinVersion = 1.3.21
 annotationsVersion = 17.0.0

--- a/src/main/kotlin/net/alexwells/kottle/FMLKotlinModLanguageProvider.kt
+++ b/src/main/kotlin/net/alexwells/kottle/FMLKotlinModLanguageProvider.kt
@@ -25,7 +25,7 @@ class FMLKotlinModLanguageProvider : IModLanguageProvider {
 
 	override fun getFileVisitor(): Consumer<ModFileScanData> {
 		return Consumer { scanResult ->
-			val modTargetMap = scanResult.annotations.stream()
+			val modTargetMap = scanResult.annotations.toList().stream()
 					.filter { ad -> ad.annotationType == FMLJavaModLanguageProvider.MODANNOTATION }
 					.peek { ad -> logger.debug(SCAN, "Found @Mod class {} with id {}", ad.classType.className, ad.annotationData["value"]) }
 					.map { ad -> FMLKotlinModTarget(ad.classType.className, ad.annotationData["value"] as String) }


### PR DESCRIPTION
when comparing ForgeSPI `0.6.0` and `0.10.0`, some time between those two versions `ModFileScanData::getAnnotations` changed it's return type from `List<AnnotationData>` to `Set<AnnotationData>`. While the code in Kottle is still valid, it was calling a `NoSuchMethodError` because the return type of `getAnnotations` was expected to be a `List`, so the JVM signature was mismatched (see #4). A simple rebuild of the project would have fixed this problem, though I added in a `::toList` method for safety in the future, in case the stated change is reverted.