### PR TITLE
README.md: Gradle script should automate mod download

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,27 @@ repositories {
     maven { url 'https://minecraft.curseforge.com/api/maven/' }
 }
 
+configurations {
+    mod
+}
+
 dependencies {
     compile "kottle:Kottle:$kottleVersion"
+    mod "kottle:Kottle:$kottleVersion"
+}
+
+task installMods(type: Copy, dependsOn: "deinstallMods") {
+    from { configurations.mod }
+    include "**/*.jar"
+    into file("run/mods")
+}
+
+task deinstallMods(type: Delete) {
+    delete fileTree(dir: "run/mods", include: "*.jar")
+}
+
+project.afterEvaluate {
+    project.tasks['prepareRuns'].dependsOn(project.tasks['installMods'])
 }
 ```
 , in your `gradle.properties`:
@@ -49,9 +68,6 @@ kottleVersion = 1.0.6
 modLoader="kotlinfml"
 loaderVersion="[1,)"
 ```
-
-Then download Kottle from [here](https://minecraft.curseforge.com/projects/kottle/files) and drop it into your `run/mods`
-folder of MDK. Create the folder if it doesn't exist.
 
 Finally, replace `FMLJavaModLoadingContext` references in your code with `FMLKotlinModLoadingContext` and
 `Mod.EventBusSubcriber` with `KotlinEventBusSubcriber`. For more info, checkout test sources 


### PR DESCRIPTION
I replaced the instruction to manually place the mod into run/mods with a gradle task that automatically does it for you. This has a few advantages:

* No manual steps required to run a mod; `./gradlew runClient` does is sufficient again
* The user can't forget to download it; it's a dependency of `prepareRuns`
* The version in `run/mods` will always be the same as the version compiled against; no room for human error