### PR TITLE
Post Forge events on mod's event bus

### DIFF
--- a/src/main/kotlin/net/alexwells/kottle/FMLKotlinModContainer.kt
+++ b/src/main/kotlin/net/alexwells/kottle/FMLKotlinModContainer.kt
@@ -113,4 +113,9 @@ class FMLKotlinModContainer(
 
     override fun matches(mod: Any): Boolean = mod === this.mod
     override fun getMod(): Any? = mod
+
+    override fun acceptEvent(e: Event)
+    {
+        eventBus.post(e)
+    }
 }


### PR DESCRIPTION
In Forge's `FMLModContainer` events received from `acceptEvent` are posted on the mod's event bus. At the moment it is not possible to handle these event when using Kottle as they are silently being dropped.  
`FMLKotlinModContainer` should probably do the same as `FMLModContainer`, post the events on the mod's event bus.