### PR TITLE
Removed the jdk 6 version of the stdlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Kotlin language provider for Forge 1.13.2+. Originally a rewrite of [Shadowfacts
 - Shades the Kotlin standard library, runtime, and reflect libraries so you don't have to.
 - Provides a Forge `IModLanguageProvider` for using Kotlin `object` classes as your main mod class and adds support for
 `object` instances for `@Mod.EventBusSubscriber`
+- Currently provides Kotlin libraries with version `1.3.50`, Kotlin coroutines version `1.3.2` and JetBrains annotations version `18.0.0`.
 
 ## Usage
 First of all, make sure you're on Forge 25.0.15 or higher.
@@ -57,11 +58,11 @@ project.afterEvaluate {
 ```
 , in your `gradle.properties`:
 ```
-# This is your kotlin gradle plugin version. For now, use 1.3.21.
-kotlinVersion = 1.3.21
+# This is your kotlin gradle plugin version. For now, use 1.3.50.
+kotlinVersion = 1.3.50
 
 # Change this to the most recent release version from CurseForge
-kottleVersion = 1.1.1
+kottleVersion = 1.2.1
 ```
 , in your `mods.toml`:
 ```toml

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,6 @@ shadowJar {
     classifier = ""
 
     dependencies {
-        include(dependency("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"))
         include(dependency("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"))
         include(dependency("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"))
         include(dependency("org.jetbrains:annotations:$annotationsVersion"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 org.gradle.jvmargs=-Xmx1G
 org.gradle.daemon=false
 
-version = 1.2.0
+version = 1.2.1
 
 mappingsChannel = snapshot
 mappingsVersion = 20190719-1.14.3


### PR DESCRIPTION
The `org.jetbrains.kotlin:kotlin-stdlib` is in conflict with the `org.jetbrains.kotlin:kotlin-stdlib-jdk8` dependency. Having both is not a good idea.

Also updated the README.