### PR TITLE
Some tidying up

### DIFF
--- a/src/main/kotlin/net/alexwells/kottle/FMLKotlinModContainer.kt
+++ b/src/main/kotlin/net/alexwells/kottle/FMLKotlinModContainer.kt
@@ -39,15 +39,15 @@ class FMLKotlinModContainer(
 
     init {
         logger.debug(LOADING, "Creating FMLModContainer instance for $className with classLoader $modClassLoader & ${javaClass.classLoader}")
-        triggerMap[ModLoadingStage.CONSTRUCT] = dummy.andThen(::constructMod).andThen(::afterEvent)
-        triggerMap[ModLoadingStage.CREATE_REGISTRIES] = dummy.andThen(::fireEvent).andThen(::afterEvent)
-        triggerMap[ModLoadingStage.LOAD_REGISTRIES] = dummy.andThen(::fireEvent).andThen(::afterEvent)
-        triggerMap[ModLoadingStage.COMMON_SETUP] = dummy.andThen(::fireEvent).andThen(::afterEvent)
-        triggerMap[ModLoadingStage.SIDED_SETUP] = dummy.andThen(::fireEvent).andThen(::afterEvent)
-        triggerMap[ModLoadingStage.ENQUEUE_IMC] = dummy.andThen(::fireEvent).andThen(::afterEvent)
-        triggerMap[ModLoadingStage.PROCESS_IMC] = dummy.andThen(::fireEvent).andThen(::afterEvent)
-        triggerMap[ModLoadingStage.COMPLETE] = dummy.andThen(::fireEvent).andThen(::afterEvent)
-        triggerMap[ModLoadingStage.GATHERDATA] = dummy.andThen(::fireEvent).andThen(::afterEvent)
+        triggerMap[ModLoadingStage.CONSTRUCT] = dummy().andThen(::constructMod).andThen(::afterEvent)
+        triggerMap[ModLoadingStage.CREATE_REGISTRIES] = dummy().andThen(::fireEvent).andThen(::afterEvent)
+        triggerMap[ModLoadingStage.LOAD_REGISTRIES] = dummy().andThen(::fireEvent).andThen(::afterEvent)
+        triggerMap[ModLoadingStage.COMMON_SETUP] = dummy().andThen(::fireEvent).andThen(::afterEvent)
+        triggerMap[ModLoadingStage.SIDED_SETUP] = dummy().andThen(::fireEvent).andThen(::afterEvent)
+        triggerMap[ModLoadingStage.ENQUEUE_IMC] = dummy().andThen(::fireEvent).andThen(::afterEvent)
+        triggerMap[ModLoadingStage.PROCESS_IMC] = dummy().andThen(::fireEvent).andThen(::afterEvent)
+        triggerMap[ModLoadingStage.COMPLETE] = dummy().andThen(::fireEvent).andThen(::afterEvent)
+        triggerMap[ModLoadingStage.GATHERDATA] = dummy().andThen(::fireEvent).andThen(::afterEvent)
         configHandler = Optional.of(Consumer { event -> eventBus.post(event) })
         val contextExtension = FMLKotlinModLoadingContext.Context(this)
         this.contextExtension = Supplier { contextExtension }
@@ -85,7 +85,7 @@ class FMLKotlinModContainer(
         logger.debug(LOADING, "Completed Automatic event subscribers for ${getModId()}")
     }
 
-    private val dummy get() = Consumer<LifecycleEventProvider.LifecycleEvent> {}
+    private fun dummy() = Consumer<LifecycleEventProvider.LifecycleEvent> {}
 
     private fun fireEvent(lifecycleEvent: LifecycleEventProvider.LifecycleEvent) {
         val event = lifecycleEvent.getOrBuildEvent(this)

--- a/src/main/kotlin/net/alexwells/kottle/FMLKotlinModContainer.kt
+++ b/src/main/kotlin/net/alexwells/kottle/FMLKotlinModContainer.kt
@@ -13,7 +13,6 @@ import net.minecraftforge.fml.ModLoadingStage
 import net.minecraftforge.forgespi.language.IModInfo
 import net.minecraftforge.forgespi.language.ModFileScanData
 import org.apache.logging.log4j.LogManager
-import java.lang.IllegalStateException
 import java.util.*
 import java.util.function.Consumer
 import java.util.function.Supplier
@@ -30,102 +29,89 @@ import java.util.function.Supplier
 class FMLKotlinModContainer(
         info: IModInfo,
         private val className: String,
-        modClassLoader: ClassLoader,
+        private val modClassLoader: ClassLoader,
         private val scanResults: ModFileScanData
 ) : ModContainer(info) {
     private val logger = LogManager.getLogger()
 
-    val eventBus: IEventBus
-    private var mod: Any? = null
-    private val modClass: Class<*>
+    private lateinit var mod: Any
+    val eventBus: IEventBus = BusBuilder.builder().setExceptionHandler(::onEventFailed).setTrackPhases(false).build()
 
     init {
-        logger.debug(LOADING, "Creating FMLModContainer instance for {} with classLoader {} & {}", className, modClassLoader, javaClass.classLoader)
-        triggerMap[ModLoadingStage.CONSTRUCT] = dummy().andThen(::beforeEvent).andThen(::constructMod).andThen(::afterEvent)
-        triggerMap[ModLoadingStage.CREATE_REGISTRIES] = dummy().andThen(::beforeEvent).andThen(::fireEvent).andThen(::afterEvent)
-        triggerMap[ModLoadingStage.LOAD_REGISTRIES] = dummy().andThen(::beforeEvent).andThen(::fireEvent).andThen(::afterEvent)
-        triggerMap[ModLoadingStage.COMMON_SETUP] = dummy().andThen(::beforeEvent).andThen(::fireEvent).andThen(::afterEvent)
-        triggerMap[ModLoadingStage.SIDED_SETUP] = dummy().andThen(::beforeEvent).andThen(::fireEvent).andThen(::afterEvent)
-        triggerMap[ModLoadingStage.ENQUEUE_IMC] = dummy().andThen(::beforeEvent).andThen(::fireEvent).andThen(::afterEvent)
-        triggerMap[ModLoadingStage.PROCESS_IMC] = dummy().andThen(::beforeEvent).andThen(::fireEvent).andThen(::afterEvent)
-        triggerMap[ModLoadingStage.COMPLETE] = dummy().andThen(::beforeEvent).andThen(::fireEvent).andThen(::afterEvent)
-        triggerMap[ModLoadingStage.GATHERDATA] = dummy().andThen(::beforeEvent).andThen(::fireEvent).andThen(::afterEvent)
-        eventBus = BusBuilder.builder().setExceptionHandler(::onEventFailed).setTrackPhases(false).build()
+        logger.debug(LOADING, "Creating FMLModContainer instance for $className with classLoader $modClassLoader & ${javaClass.classLoader}")
+        triggerMap[ModLoadingStage.CONSTRUCT] = dummy.andThen(::constructMod).andThen(::afterEvent)
+        triggerMap[ModLoadingStage.CREATE_REGISTRIES] = dummy.andThen(::fireEvent).andThen(::afterEvent)
+        triggerMap[ModLoadingStage.LOAD_REGISTRIES] = dummy.andThen(::fireEvent).andThen(::afterEvent)
+        triggerMap[ModLoadingStage.COMMON_SETUP] = dummy.andThen(::fireEvent).andThen(::afterEvent)
+        triggerMap[ModLoadingStage.SIDED_SETUP] = dummy.andThen(::fireEvent).andThen(::afterEvent)
+        triggerMap[ModLoadingStage.ENQUEUE_IMC] = dummy.andThen(::fireEvent).andThen(::afterEvent)
+        triggerMap[ModLoadingStage.PROCESS_IMC] = dummy.andThen(::fireEvent).andThen(::afterEvent)
+        triggerMap[ModLoadingStage.COMPLETE] = dummy.andThen(::fireEvent).andThen(::afterEvent)
+        triggerMap[ModLoadingStage.GATHERDATA] = dummy.andThen(::fireEvent).andThen(::afterEvent)
         configHandler = Optional.of(Consumer { event -> eventBus.post(event) })
-
         val contextExtension = FMLKotlinModLoadingContext.Context(this)
         this.contextExtension = Supplier { contextExtension }
-
-        try {
-            // Here, we won't init the class, meaning static {} blocks (init {} in kotlin) won't get triggered
-            // but we will still have to do it later, on CONSTRUCT phase.
-            modClass = Class.forName(className, false, modClassLoader)
-            logger.debug(LOADING, "Loaded modclass {} with {}", modClass.name, modClass.classLoader)
-        } catch (e: Throwable) {
-            logger.error(LOADING, "Failed to load class {}", className, e)
-            throw ModLoadingException(info, ModLoadingStage.CONSTRUCT, "fml.modloading.failedtoloadmodclass", e)
-        }
     }
 
     private fun constructMod(event: LifecycleEventProvider.LifecycleEvent) {
+        // Here we'll load the class
+        val modClass = try {
+            Class.forName(className, true, modClassLoader).also {
+                logger.debug(LOADING, "Loaded modclass ${it.name} with ${it.classLoader}")
+            }
+        } catch (e: Throwable) {
+            logger.error(LOADING, "Failed to load class $className", e)
+            throw ModLoadingException(modInfo, ModLoadingStage.CONSTRUCT, "fml.modloading.failedtoloadmodclass", e)
+        }
+        // Then we check whether it's a kotlin object and return it, or if not we create a new instance of kotlin class.
         try {
-            logger.debug(LOADING, "Loading mod instance {} of type {}", getModId(), modClass.name)
-            // Now we can load the class, so that static {} block gets called
-            Class.forName(className) // todo: use modClassLoader? IMPORTANT
-            // Then we check whether it's a kotlin object and return it, or if not we create a new instance of kotlin class.
+            logger.debug(LOADING, "Loading mod instance ${getModId()} of type $className")
             this.mod = modClass.kotlin.objectInstance ?: modClass.getConstructor().newInstance()
-            logger.debug(LOADING, "Loaded mod instance {} of type {}", getModId(), modClass.name)
+            logger.debug(LOADING, "Loaded mod instance ${getModId()} of type $className")
         } catch (e: Throwable) {
             if (e is IllegalStateException) {
-                logger.error(
-                        LOADING,
-                        "This seems like a compatibility error between Kottle and the mod. " +
-                                "Please make sure identical versions of shadowed libraries are used in the mod and Kottle of this version."
+                logger.error(LOADING, "This seems like a compatibility error between Kottle and the mod. " +
+                        "Please make sure identical versions of shadowed libraries are used in the mod and Kottle of this version."
                 )
             }
 
-            logger.error(LOADING, "Failed to create mod instance. ModID: {}, class {}", getModId(), modClass.name, e)
+            logger.error(LOADING, "Failed to create mod instance. ModID: ${getModId()}, class $className", e)
 
             throw ModLoadingException(modInfo, event.fromStage(), "fml.modloading.failedtoloadmod", e, modClass)
         }
 
-        logger.debug(LOADING, "Injecting Automatic event subscribers for {}", getModId())
-        KotlinAutomaticEventSubscriber.inject(this, this.scanResults, this.modClass.classLoader)
-        logger.debug(LOADING, "Completed Automatic event subscribers for {}", getModId())
+        logger.debug(LOADING, "Injecting Automatic event subscribers for ${getModId()}")
+        KotlinAutomaticEventSubscriber.inject(this, scanResults, modClass.classLoader)
+        logger.debug(LOADING, "Completed Automatic event subscribers for ${getModId()}")
     }
 
-    private fun dummy(): Consumer<LifecycleEventProvider.LifecycleEvent> = Consumer {}
-
-    private fun beforeEvent(lifecycleEvent: LifecycleEventProvider.LifecycleEvent) {}
+    private val dummy get() = Consumer<LifecycleEventProvider.LifecycleEvent> {}
 
     private fun fireEvent(lifecycleEvent: LifecycleEventProvider.LifecycleEvent) {
         val event = lifecycleEvent.getOrBuildEvent(this)
-        logger.debug(LOADING, "Firing event for modid {} : {}", this.getModId(), event)
+        logger.debug(LOADING, "Firing event for modid ${getModId()} : $event")
         try {
             eventBus.post(event)
-            logger.debug(LOADING, "Fired event for modid {} : {}", this.getModId(), event)
+            logger.debug(LOADING, "Fired event for modid ${getModId()} : $event")
         } catch (e: Throwable) {
-            logger.error(LOADING, "Caught exception during event {} dispatch for modid {}", event, this.getModId(), e)
+            logger.error(LOADING, "Caught exception during event $event dispatch for modid ${getModId()}", e)
             throw ModLoadingException(modInfo, lifecycleEvent.fromStage(), "fml.modloading.errorduringevent", e)
         }
-
     }
 
     private fun afterEvent(lifecycleEvent: LifecycleEventProvider.LifecycleEvent) {
         if (currentState == ModLoadingStage.ERROR) {
-            logger.error(LOADING, "An error occurred while dispatching event {} to {}", lifecycleEvent.fromStage(), getModId())
+            logger.error(LOADING, "An error occurred while dispatching event ${lifecycleEvent.fromStage()} to ${getModId()}")
         }
     }
 
-    private fun onEventFailed(iEventBus: IEventBus, event: Event, iEventListeners: Array<IEventListener>, i: Int, throwable: Throwable) {
-        logger.error(EventBusErrorMessage(event, i, iEventListeners, throwable))
-    }
+    private fun onEventFailed(iEventBus: IEventBus, event: Event, iEventListeners: Array<IEventListener>, i: Int, throwable: Throwable) =
+            logger.error(EventBusErrorMessage(event, i, iEventListeners, throwable))
 
-    override fun matches(mod: Any): Boolean = mod === this.mod
-    override fun getMod(): Any? = mod
+    override fun matches(mod: Any) = mod === this.mod
+    override fun getMod() = mod
 
-    override fun acceptEvent(e: Event)
-    {
+    override fun acceptEvent(e: Event) {
         eventBus.post(e)
     }
 }

--- a/src/main/kotlin/net/alexwells/kottle/FMLKotlinModLanguageProvider.kt
+++ b/src/main/kotlin/net/alexwells/kottle/FMLKotlinModLanguageProvider.kt
@@ -9,30 +9,30 @@ import net.minecraftforge.forgespi.language.ModFileScanData
 import org.apache.logging.log4j.LogManager
 import java.util.function.Consumer
 import java.util.function.Supplier
-import java.util.stream.Collectors
 
 /**
  * Similar to FMLJavaModLanguageProvider
  */
 class FMLKotlinModLanguageProvider : IModLanguageProvider {
-	private val logger = LogManager.getLogger()
+    private val logger = LogManager.getLogger()
 
-	init {
-		logger.debug(LOADING, "Init FMLKotlinModLanguageProvider")
-	}
+    init {
+        logger.debug(LOADING, "Init FMLKotlinModLanguageProvider")
+    }
 
-	override fun name(): String  = "kotlinfml"
+    override fun name() = "kotlinfml"
 
-	override fun getFileVisitor(): Consumer<ModFileScanData> {
-		return Consumer { scanResult ->
-			val modTargetMap = scanResult.annotations.toList().stream()
-					.filter { ad -> ad.annotationType == FMLJavaModLanguageProvider.MODANNOTATION }
-					.peek { ad -> logger.debug(SCAN, "Found @Mod class {} with id {}", ad.classType.className, ad.annotationData["value"]) }
-					.map { ad -> FMLKotlinModTarget(ad.classType.className, ad.annotationData["value"] as String) }
-					.collect(Collectors.toMap(java.util.function.Function<FMLKotlinModTarget, String> { it.modId }, java.util.function.Function.identity<FMLKotlinModTarget>()))
-			scanResult.addLanguageLoader(modTargetMap)
-		}
-	}
+    override fun getFileVisitor() = Consumer<ModFileScanData> { scanResult ->
+        val modTargetMap = scanResult.annotations.asSequence()
+                .filter { it.annotationType == FMLJavaModLanguageProvider.MODANNOTATION }
+                .map { ad ->
+                    val className = ad.classType.className
+                    val modId = ad.annotationData["value"] as String
+                    logger.debug(SCAN, "Found @Mod class $className with id $modId")
+                    modId to FMLKotlinModTarget(className)
+                }.toMap()
+        scanResult.addLanguageLoader(modTargetMap)
+    }
 
-	override fun <R : ILifecycleEvent<R>?> consumeLifecycleEvent(consumeEvent: Supplier<R>?) {}
+    override fun <R : ILifecycleEvent<R>?> consumeLifecycleEvent(consumeEvent: Supplier<R>?) {}
 }

--- a/src/main/kotlin/net/alexwells/kottle/FMLKotlinModLanguageProvider.kt
+++ b/src/main/kotlin/net/alexwells/kottle/FMLKotlinModLanguageProvider.kt
@@ -23,7 +23,7 @@ class FMLKotlinModLanguageProvider : IModLanguageProvider {
     override fun name() = "kotlinfml"
 
     override fun getFileVisitor() = Consumer<ModFileScanData> { scanResult ->
-        val modTargetMap = scanResult.annotations.asSequence()
+        val modTargetMap = scanResult.annotations
                 .filter { it.annotationType == FMLJavaModLanguageProvider.MODANNOTATION }
                 .map { ad ->
                     val className = ad.classType.className

--- a/src/main/kotlin/net/alexwells/kottle/FMLKotlinModLoadingContext.kt
+++ b/src/main/kotlin/net/alexwells/kottle/FMLKotlinModLoadingContext.kt
@@ -1,18 +1,14 @@
 package net.alexwells.kottle
 
-import net.minecraftforge.eventbus.api.IEventBus
 import net.minecraftforge.fml.ModLoadingContext
 
 /**
  * Similar to FMLModLoadingContext.
  */
 object FMLKotlinModLoadingContext {
-    fun get(): Context {
-        return ModLoadingContext.get().extension()
-    }
+    fun get(): Context = ModLoadingContext.get().extension()
 
     class Context(private val container: FMLKotlinModContainer) {
-        val modEventBus: IEventBus
-            get() = container.eventBus
+        val modEventBus get() = container.eventBus
     }
 }

--- a/src/main/kotlin/net/alexwells/kottle/FMLKotlinModTarget.kt
+++ b/src/main/kotlin/net/alexwells/kottle/FMLKotlinModTarget.kt
@@ -5,30 +5,28 @@ import net.minecraftforge.forgespi.language.IModInfo
 import net.minecraftforge.forgespi.language.IModLanguageProvider
 import net.minecraftforge.forgespi.language.ModFileScanData
 import org.apache.logging.log4j.LogManager
+import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.javaMethod
 
 /**
  * Similar to FMLModTarget, just with ModContainer class changed.
  */
-class FMLKotlinModTarget(private val className: String, val modId: String) : IModLanguageProvider.IModLanguageLoader {
+class FMLKotlinModTarget(private val className: String) : IModLanguageProvider.IModLanguageLoader {
     private val logger = LogManager.getLogger()
 
-    override fun <T> loadMod(info: IModInfo, modClassLoader: ClassLoader, modFileScanResults: ModFileScanData): T {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> loadMod(info: IModInfo, modClassLoader: ClassLoader, modFileScanResults: ModFileScanData) = try {
         // We can NOT just instantiate FMLKotlinModContainer() directly, because that would use the wrong class loader,
         // which has a different reference to the ModContainer class, meaning ModLoader will throw CannotCastException
         // as soon as it tries to load any mod. Instead, we'll use the exact same thing as FMLModTarget uses -
         // thread-bound class loader, set somewhere deep in the Forge sources. Do NOT try to change this.
-        try {
-            logger.debug(LOADING, "Loading FMLKotlinModContainer from classloader {}", Thread.currentThread().contextClassLoader)
-            val fmlContainer = Class.forName("net.alexwells.kottle.FMLKotlinModContainer", true, Thread.currentThread().contextClassLoader)
-            logger.debug(LOADING, "Loading FMLKotlinModContainer got {}", fmlContainer.classLoader)
-
-            @Suppress("UNCHECKED_CAST")
-            return fmlContainer
-                    .getConstructor(IModInfo::class.java, String::class.java, ClassLoader::class.java, ModFileScanData::class.java)
-                    .newInstance(info, className, modClassLoader, modFileScanResults) as T
-        } catch (e: ReflectiveOperationException) {
-            logger.fatal(LOADING, "Unable to load FMLKotlinModContainer, wut?", e)
-            throw e
-        }
+        logger.debug(LOADING, "Loading FMLKotlinModContainer from classloader ${Thread.currentThread().contextClassLoader}")
+        Class.forName("net.alexwells.kottle.FMLKotlinModContainer", true, Thread.currentThread().contextClassLoader)
+                .also { logger.debug(LOADING, "Loading FMLKotlinModContainer got ${it.classLoader}") }
+                .kotlin.primaryConstructor?.javaMethod
+                ?.invoke(info, className, modClassLoader, modFileScanResults) as T
+    } catch (e: ReflectiveOperationException) {
+        logger.fatal(LOADING, "Unable to load FMLKotlinModContainer, wut?", e)
+        throw e
     }
 }

--- a/src/main/kotlin/net/alexwells/kottle/FMLKotlinModTarget.kt
+++ b/src/main/kotlin/net/alexwells/kottle/FMLKotlinModTarget.kt
@@ -6,7 +6,6 @@ import net.minecraftforge.forgespi.language.IModLanguageProvider
 import net.minecraftforge.forgespi.language.ModFileScanData
 import org.apache.logging.log4j.LogManager
 import kotlin.reflect.full.primaryConstructor
-import kotlin.reflect.jvm.javaMethod
 
 /**
  * Similar to FMLModTarget, just with ModContainer class changed.
@@ -23,8 +22,7 @@ class FMLKotlinModTarget(private val className: String) : IModLanguageProvider.I
         logger.debug(LOADING, "Loading FMLKotlinModContainer from classloader ${Thread.currentThread().contextClassLoader}")
         Class.forName("net.alexwells.kottle.FMLKotlinModContainer", true, Thread.currentThread().contextClassLoader)
                 .also { logger.debug(LOADING, "Loading FMLKotlinModContainer got ${it.classLoader}") }
-                .kotlin.primaryConstructor?.javaMethod
-                ?.invoke(info, className, modClassLoader, modFileScanResults) as T
+                .kotlin.primaryConstructor?.call(info, className, modClassLoader, modFileScanResults) as T
     } catch (e: ReflectiveOperationException) {
         logger.fatal(LOADING, "Unable to load FMLKotlinModContainer, wut?", e)
         throw e

--- a/src/main/kotlin/net/alexwells/kottle/KotlinEventBusSubscriber.kt
+++ b/src/main/kotlin/net/alexwells/kottle/KotlinEventBusSubscriber.kt
@@ -1,9 +1,9 @@
 package net.alexwells.kottle
 
+import net.alexwells.kottle.KotlinEventBusSubscriber.Bus
 import net.minecraftforge.api.distmarker.Dist
 import net.minecraftforge.common.MinecraftForge
 import net.minecraftforge.eventbus.api.IEventBus
-import java.util.function.Supplier
 
 /**
  * Annotate a class which will be subscribed to an Event Bus at mod construction time.
@@ -37,21 +37,17 @@ annotation class KotlinEventBusSubscriber(
          */
         val bus: Bus = Bus.FORGE
 ) {
-    enum class Bus private constructor(private val busSupplier: Supplier<IEventBus>) {
+    enum class Bus private constructor(val busSupplier: () -> IEventBus) {
         /**
          * The main Forge Event Bus.
          * @see MinecraftForge.EVENT_BUS
          */
-        FORGE(Supplier { MinecraftForge.EVENT_BUS }),
+        FORGE({ MinecraftForge.EVENT_BUS }),
 
         /**
          * The mod specific Event bus.
          * @see FMLKotlinModLoadingContext.get().modEventBus
          */
-        MOD(Supplier { FMLKotlinModLoadingContext.get().modEventBus });
-
-        fun bus(): Supplier<IEventBus> {
-            return busSupplier
-        }
+        MOD({ FMLKotlinModLoadingContext.get().modEventBus });
     }
 }


### PR DESCRIPTION
This PR has the goal of changing up the code to be `kotlinic` and readable without making any changes to the actual functionality. This includes:
 - using String interpolation
 - using lateinit instead of having nullable variables
 - replacing streams with Kotlin iteration methods
 - removing braces on functions where possible
 - removing some unneeded functions
 - chaining functions instead of creating one-use variables where possible
 - relying on type inference where possible