### PR TITLE
Allow usage of @Mod.EventBusSubscriber

### DIFF
--- a/src/main/kotlin/net/alexwells/kottle/KotlinAutomaticEventSubscriber.kt
+++ b/src/main/kotlin/net/alexwells/kottle/KotlinAutomaticEventSubscriber.kt
@@ -1,48 +1,60 @@
 package net.alexwells.kottle
 
 import net.minecraftforge.api.distmarker.Dist
+import net.minecraftforge.common.MinecraftForge
 import net.minecraftforge.fml.Logging
 import net.minecraftforge.fml.ModContainer
+import net.minecraftforge.fml.common.Mod
 import net.minecraftforge.fml.loading.FMLEnvironment
 import net.minecraftforge.fml.loading.moddiscovery.ModAnnotation
 import net.minecraftforge.forgespi.language.ModFileScanData
 import org.apache.logging.log4j.LogManager
 import org.objectweb.asm.Type
+import java.util.*
+import java.util.stream.Collectors
+import kotlin.collections.ArrayList
 
 /**
  * Similar to AutomaticEventSubscriber, but with support for kotlin objects.
  */
+@Suppress("DEPRECATION")
 object KotlinAutomaticEventSubscriber {
     private val AUTO_SUBSCRIBER = Type.getType(KotlinEventBusSubscriber::class.java)
+    private val EVENT_BUS_SUBSCRIBER = Type.getType(Mod.EventBusSubscriber::class.java)
 
     private val logger = LogManager.getLogger()
 
-    fun inject(mod: ModContainer, scanData: ModFileScanData?, loader: ClassLoader) = if (scanData == null) run { } else scanData.annotations
-            .also { logger.debug(Logging.LOADING, "Attempting to inject @EventBusSubscriber classes into the eventbus for ${mod.modId}") }
-            .filter { it.annotationType == AUTO_SUBSCRIBER && shouldBeRegistered(mod.modId, it) }
-            .forEach { ad ->
-                val busTarget = (ad.annotationData["bus"] as? ModAnnotation.EnumHolder)
-                        ?.let { KotlinEventBusSubscriber.Bus.valueOf(it.value) }
-                        ?: KotlinEventBusSubscriber.Bus.FORGE
-
+    @Suppress("UNCHECKED_CAST")
+    fun inject(mod: ModContainer, scanData: ModFileScanData, classLoader: ClassLoader) {
+        logger.debug(Logging.LOADING, "Attempting to inject @EventBusSubscriber kotlin objects in to the event bus for {}", mod.modId)
+        val data: ArrayList<ModFileScanData.AnnotationData> = scanData.annotations.stream()
+                .filter { annotationData ->
+                    EVENT_BUS_SUBSCRIBER == annotationData.annotationType ||
+                            AUTO_SUBSCRIBER == annotationData.annotationType
+                }
+                .collect(Collectors.toList()) as ArrayList<ModFileScanData.AnnotationData>
+        data.forEach { annotationData ->
+            val sidesValue: List<ModAnnotation.EnumHolder> = annotationData.annotationData.getOrDefault("value", listOf(ModAnnotation.EnumHolder(null, "CLIENT"), ModAnnotation.EnumHolder(null, "DEDICATED_SERVER"))) as List<ModAnnotation.EnumHolder>
+            val sides: EnumSet<Dist> = sidesValue.stream().map { eh -> Dist.valueOf(eh.value) }
+                    .collect(Collectors.toCollection { EnumSet.noneOf(Dist::class.java) })
+            val modid = annotationData.annotationData.getOrDefault("modid", mod.modId)
+            val busTargetHolder: ModAnnotation.EnumHolder = annotationData.annotationData.getOrDefault("bus", ModAnnotation.EnumHolder(null, "FORGE")) as ModAnnotation.EnumHolder
+            val busTarget = Mod.EventBusSubscriber.Bus.valueOf(busTargetHolder.value)
+            val ktObject = Class.forName(annotationData.classType.className, true, classLoader).kotlin.objectInstance
+            if (ktObject !== null && mod.modId == modid && sides.contains(FMLEnvironment.dist)) {
                 try {
-                    logger.debug(Logging.LOADING, "Auto-subscribing ${ad.classType.className} to $busTarget")
-                    val clazz = Class.forName(ad.classType.className, true, loader)
-                    busTarget.busSupplier().register(clazz.kotlin.objectInstance ?: clazz)
-                } catch (e: ClassNotFoundException) {
-                    logger.fatal(Logging.LOADING, "Failed to load mod class ${ad.classType} for @EventBusSubscriber annotation", e)
-                    throw e
+                    logger.debug(Logging.LOADING, "Auto-subscribing kotlin object {} to {}", annotationData.classType.className, busTarget)
+                    if (busTarget === Mod.EventBusSubscriber.Bus.MOD) {
+                        // Gets the correct mod loading context
+                        FMLKotlinModLoadingContext.get().modEventBus.register(ktObject)
+                    } else {
+                        MinecraftForge.EVENT_BUS.register(ktObject)
+                    }
+                } catch (e: Throwable) {
+                    logger.fatal(Logging.LOADING, "Failed to load mod class {} for @EventBusSubscriber annotation", annotationData.classType, e)
+                    throw RuntimeException(e)
                 }
             }
-
-    private fun shouldBeRegistered(modId: String, ad: ModFileScanData.AnnotationData): Boolean {
-        @Suppress("UNCHECKED_CAST")
-        val sides = (ad.annotationData["value"] as? List<ModAnnotation.EnumHolder>)
-                ?.map { Dist.valueOf(it.value) }
-                ?: listOf(Dist.CLIENT, Dist.DEDICATED_SERVER)
-
-        val annotationModId = ad.annotationData.getOrDefault("modid", modId) as String
-
-        return modId == annotationModId && FMLEnvironment.dist in sides
+        }
     }
 }

--- a/src/main/kotlin/net/alexwells/kottle/KotlinEventBusSubscriber.kt
+++ b/src/main/kotlin/net/alexwells/kottle/KotlinEventBusSubscriber.kt
@@ -14,6 +14,10 @@ import net.minecraftforge.eventbus.api.IEventBus
  */
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FILE)
+@Deprecated(
+        message = "Use @Mod.EventBusSubscriber instead",
+        replaceWith = ReplaceWith("@Mod.EventBusSubscriber", "net.minecraftforge.fml.common.Mod")
+)
 annotation class KotlinEventBusSubscriber(
     /**
      * Specify targets to load this event subscriber on. Can be used to avoid loading Client specific events


### PR DESCRIPTION
This patch deprecates @KotlinEventBusSubscriber and adds functionality in KotlinAutomaticEventSubscriber to allow usage of @Mod.EventBusSubscriber. It deprecates @KotlinEventBusSubscriber because mods should be using the official forge annotations instead of a separate annotation.