### PR TITLE
Add mods.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,27 +33,8 @@ repositories {
     maven { url 'https://minecraft.curseforge.com/api/maven/' }
 }
 
-configurations {
-    mod
-}
-
 dependencies {
-    compile "kottle:Kottle:$kottleVersion"
-    mod "kottle:Kottle:$kottleVersion"
-}
-
-task installMods(type: Copy, dependsOn: "deinstallMods") {
-    from { configurations.mod }
-    include "**/*.jar"
-    into file("run/mods")
-}
-
-task deinstallMods(type: Delete) {
-    delete fileTree(dir: "run/mods", include: "*.jar")
-}
-
-project.afterEvaluate {
-    project.tasks['prepareRuns'].dependsOn(project.tasks['installMods'])
+    implementation "kottle:Kottle:$kottleVersion"
 }
 ```
 , in your `gradle.properties`:

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,0 +1,14 @@
+modLoader="javafml"
+loaderVersion="[28,)"
+
+[[mods]]
+    modId="kottle"
+    version="1.3.0"
+    type="LANGPROVIDER"
+
+[[dependencies.kottle]]
+    modId="forge"
+    mandatory=true
+    versionRange="[28,)"
+    ordering="NONE"
+    side="BOTH"


### PR DESCRIPTION
Adds a mods.toml file with mod type set to `LANGPROVIDER`. This removes the need to have the Kottle  jar file in the mods directory when developing.