### PR TITLE
Fix missing stdlib-jdk7 transitive dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,28 +104,24 @@ repositories {
     jcenter()
 }
 
+configurations {
+    compile.extendsFrom(shade)
+}
+
 dependencies {
     minecraft forgeVersion
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
-    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
-    compile "org.jetbrains:annotations:$annotationsVersion"
-    compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
-    compile "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$coroutinesVersion"
+    shade "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    shade "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+    shade "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+    shade "org.jetbrains:annotations:$annotationsVersion"
+    shade "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
+    shade "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$coroutinesVersion"
 }
 
 shadowJar {
     classifier = ''
-
-    dependencies {
-        include(dependency("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"))
-        include(dependency("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"))
-        include(dependency("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"))
-        include(dependency("org.jetbrains:annotations:$annotationsVersion"))
-        include(dependency("org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutinesVersion}"))
-        include(dependency("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:${coroutinesVersion}"))
-    }
+    configurations = [project.configurations.shade]
 }
 
 tasks.build.dependsOn shadowJar

--- a/tests/integration/src/main/kotlin/net/alexwells/kottle/integrationtest/KottleIntegrationTest.kt
+++ b/tests/integration/src/main/kotlin/net/alexwells/kottle/integrationtest/KottleIntegrationTest.kt
@@ -55,6 +55,9 @@ object KottleIntegrationTest {
             "success!"
         }
 
+        // https://github.com/autaut03/kottle/pull/26
+        logger.info("Random int: ${listOf(1, 2, 3).random()}")
+
         job = GlobalScope.launch {
             logger.info("Future dispatched")
             future.await().also { logger.info("Kotlin Coroutine (with JRE8 Extension) Test: $it") }


### PR DESCRIPTION
The current build (1.5.0) doesn't include `kotlin-stdlib-jdk7`, which is a transitive dependency of `kotlin-stdlib-jdk8`. This just fixes the gradle script so it includes transitive dependencies.

This issue only shows up in a select few cases, including using the `AutoClosable.use {}` method (which is only present in `kotlin-stdlib-jdk7`) and using the default `kotlin.random.Random` instance (which is present on `JDK8PlatformImplementations`, which extends the missing `JDK7PlatformImplementations` class)

Here's a snippet of the error I encountered when trying to access the `Collection<T>.random(): T` method: 
```
[00:43:55] [Render thread/ERROR] [ne.mi.ev.EventSubclassTransformer/EVENTBUS]: Could not find parent kotlin/internal/jdk7/JDK7PlatformImplementations for class kotlin/internal/jdk8/JDK8PlatformImplementations in classloader cpw.mods.modlauncher.TransformingClassLoader@149b0577 on thread Thread[Render thread,5,main]
[00:43:55] [Render thread/ERROR] [ne.mi.ev.EventSubclassTransformer/EVENTBUS]: An error occurred building event handler
java.lang.ClassNotFoundException: kotlin.internal.jdk7.JDK7PlatformImplementations
	at java.lang.ClassLoader.findClass(ClassLoader.java:530) ~[?:1.8.0_181] {}
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424) ~[?:1.8.0_181] {}
	at cpw.mods.modlauncher.TransformingClassLoader.loadClass(TransformingClassLoader.java:101) ~[modlauncher-5.0.0-milestone.4.jar:?] {re:classloading}
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[?:1.8.0_181] {}
	at net.minecraftforge.eventbus.EventSubclassTransformer.buildEvents(EventSubclassTransformer.java:62) ~[eventbus-2.0.0-milestone.1-service.jar:?] {}
	at net.minecraftforge.eventbus.EventSubclassTransformer.transform(EventSubclassTransformer.java:44) ~[eventbus-2.0.0-milestone.1-service.jar:?] {}
	at net.minecraftforge.eventbus.EventBusEngine.processClass(EventBusEngine.java:20) ~[eventbus-2.0.0-milestone.1-service.jar:?] {}
	at net.minecraftforge.eventbus.service.ModLauncherService.processClass(ModLauncherService.java:20) ~[eventbus-2.0.0-milestone.1-service.jar:2.0.0-milestone.1+57+de55078] {}
	at cpw.mods.modlauncher.LaunchPluginHandler.offerClassNodeToPlugins(LaunchPluginHandler.java:85) ~[modlauncher-5.0.0-milestone.4.jar:?] {}
	at cpw.mods.modlauncher.ClassTransformer.transform(ClassTransformer.java:115) ~[modlauncher-5.0.0-milestone.4.jar:?] {}
	at cpw.mods.modlauncher.TransformingClassLoader$DelegatedClassLoader.findClass(TransformingClassLoader.java:239) ~[modlauncher-5.0.0-milestone.4.jar:?] {}
	at cpw.mods.modlauncher.TransformingClassLoader.loadClass(TransformingClassLoader.java:126) ~[modlauncher-5.0.0-milestone.4.jar:?] {re:classloading}
	at cpw.mods.modlauncher.TransformingClassLoader.loadClass(TransformingClassLoader.java:96) ~[modlauncher-5.0.0-milestone.4.jar:?] {re:classloading}
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[?:1.8.0_181] {}
	at java.lang.Class.forName0(Native Method) ~[?:1.8.0_181] {}
	at java.lang.Class.forName(Class.java:264) ~[?:1.8.0_181] {}
	at kotlin.internal.PlatformImplementationsKt.<clinit>(PlatformImplementations.kt:41) ~[?:?] {re:classloading}
	at kotlin.random.Random.<clinit>(Random.kt:242) ~[?:?] {re:classloading}
```