### PR TITLE
Fix constructor errors appearing as classloading errors

### DIFF
--- a/src/main/kotlin/net/alexwells/kottle/FMLKotlinModContainer.kt
+++ b/src/main/kotlin/net/alexwells/kottle/FMLKotlinModContainer.kt
@@ -56,7 +56,7 @@ class FMLKotlinModContainer(
     private fun constructMod(event: LifecycleEventProvider.LifecycleEvent) {
         // Here we'll load the class
         val modClass = try {
-            Class.forName(className, true, modClassLoader).also {
+            Class.forName(className, false, modClassLoader).also {
                 logger.debug(LOADING, "Loaded modclass ${it.name} with ${it.classLoader}")
             }
         } catch (e: Throwable) {


### PR DESCRIPTION
Currently, if an error occurs creating a Kotlin `object`, FML will classify it as a classloading error on the "error loading game" screen. This is because an object's constructor is called when the class is loaded (due to the auto-generated `public static final INSTANCE = new TheObjectType();`), causing an error in the classloading try/catch. By changing the class loading section so it doesn't run static initializers those errors will instead be correctly picked up by the mod construction try/catch.