### PR TITLE
Remove unnecessary objects

### DIFF
--- a/src/main/kotlin/net/alexwells/kottle/FMLKotlinModContainer.kt
+++ b/src/main/kotlin/net/alexwells/kottle/FMLKotlinModContainer.kt
@@ -49,7 +49,7 @@ class FMLKotlinModContainer(
         triggerMap[ModLoadingStage.COMPLETE] = dummy().andThen(::fireEvent).andThen(::afterEvent)
         triggerMap[ModLoadingStage.GATHERDATA] = dummy().andThen(::fireEvent).andThen(::afterEvent)
         configHandler = Optional.of(Consumer { event -> eventBus.post(event) })
-        val contextExtension = FMLKotlinModLoadingContext.Context(this)
+        val contextExtension = Context(this)
         this.contextExtension = Supplier { contextExtension }
     }
 
@@ -81,7 +81,7 @@ class FMLKotlinModContainer(
         }
 
         logger.debug(LOADING, "Injecting Automatic event subscribers for ${getModId()}")
-        KotlinAutomaticEventSubscriber.inject(this, scanResults, modClass.classLoader)
+        injectSubscribers(this, scanResults, modClass.classLoader)
         logger.debug(LOADING, "Completed Automatic event subscribers for ${getModId()}")
     }
 

--- a/src/main/kotlin/net/alexwells/kottle/FMLKotlinModContainer.kt
+++ b/src/main/kotlin/net/alexwells/kottle/FMLKotlinModContainer.kt
@@ -65,9 +65,9 @@ class FMLKotlinModContainer(
         }
         // Then we check whether it's a kotlin object and return it, or if not we create a new instance of kotlin class.
         try {
-            logger.debug(LOADING, "Loading mod instance ${getModId()} of type $className")
+            logger.debug(LOADING, "Loading mod instance $modId of type $className")
             this.mod = modClass.kotlin.objectInstance ?: modClass.getConstructor().newInstance()
-            logger.debug(LOADING, "Loaded mod instance ${getModId()} of type $className")
+            logger.debug(LOADING, "Loaded mod instance $modId of type $className")
         } catch (e: Throwable) {
             if (e is IllegalStateException) {
                 logger.error(LOADING, "This seems like a compatibility error between Kottle and the mod. " +
@@ -75,33 +75,33 @@ class FMLKotlinModContainer(
                 )
             }
 
-            logger.error(LOADING, "Failed to create mod instance. ModID: ${getModId()}, class $className", e)
+            logger.error(LOADING, "Failed to create mod instance. ModID: $modId, class $className", e)
 
             throw ModLoadingException(modInfo, event.fromStage(), "fml.modloading.failedtoloadmod", e, modClass)
         }
 
-        logger.debug(LOADING, "Injecting Automatic event subscribers for ${getModId()}")
+        logger.debug(LOADING, "Injecting Automatic event subscribers for $modId")
         injectSubscribers(this, scanResults, modClass.classLoader)
-        logger.debug(LOADING, "Completed Automatic event subscribers for ${getModId()}")
+        logger.debug(LOADING, "Completed Automatic event subscribers for $modId")
     }
 
     private fun dummy() = Consumer<LifecycleEventProvider.LifecycleEvent> {}
 
     private fun fireEvent(lifecycleEvent: LifecycleEventProvider.LifecycleEvent) {
         val event = lifecycleEvent.getOrBuildEvent(this)
-        logger.debug(LOADING, "Firing event for modid ${getModId()} : $event")
+        logger.debug(LOADING, "Firing event for modid $modId : $event")
         try {
             eventBus.post(event)
-            logger.debug(LOADING, "Fired event for modid ${getModId()} : $event")
+            logger.debug(LOADING, "Fired event for modid $modId : $event")
         } catch (e: Throwable) {
-            logger.error(LOADING, "Caught exception during event $event dispatch for modid ${getModId()}", e)
+            logger.error(LOADING, "Caught exception during event $event dispatch for modid $modId", e)
             throw ModLoadingException(modInfo, lifecycleEvent.fromStage(), "fml.modloading.errorduringevent", e)
         }
     }
 
     private fun afterEvent(lifecycleEvent: LifecycleEventProvider.LifecycleEvent) {
         if (currentState == ModLoadingStage.ERROR) {
-            logger.error(LOADING, "An error occurred while dispatching event ${lifecycleEvent.fromStage()} to ${getModId()}")
+            logger.error(LOADING, "An error occurred while dispatching event ${lifecycleEvent.fromStage()} to $modId")
         }
     }
 

--- a/src/main/kotlin/net/alexwells/kottle/FMLKotlinModLoadingContext.kt
+++ b/src/main/kotlin/net/alexwells/kottle/FMLKotlinModLoadingContext.kt
@@ -2,13 +2,8 @@ package net.alexwells.kottle
 
 import net.minecraftforge.fml.ModLoadingContext
 
-/**
- * Similar to FMLModLoadingContext.
- */
-object FMLKotlinModLoadingContext {
-    fun get(): Context = ModLoadingContext.get().extension()
+val modLoadingContext: Context get() = ModLoadingContext.get().extension()
 
-    class Context(private val container: FMLKotlinModContainer) {
-        val modEventBus get() = container.eventBus
-    }
+class Context(private val container: FMLKotlinModContainer) {
+    val modEventBus get() = container.eventBus
 }

--- a/src/main/kotlin/net/alexwells/kottle/KotlinAutomaticEventSubscriber.kt
+++ b/src/main/kotlin/net/alexwells/kottle/KotlinAutomaticEventSubscriber.kt
@@ -14,39 +14,36 @@ import org.objectweb.asm.Type
 /**
  * Similar to AutomaticEventSubscriber, but with support for kotlin objects.
  */
-@Suppress("DEPRECATION")
-object KotlinAutomaticEventSubscriber {
-    private val FORGE_SUBSCRIBER = Type.getType(Mod.EventBusSubscriber::class.java)
+private val FORGE_SUBSCRIBER = Type.getType(Mod.EventBusSubscriber::class.java)
 
-    private val logger = LogManager.getLogger()
+private val logger = LogManager.getLogger()
 
-    fun inject(mod: ModContainer, scanData: ModFileScanData?, loader: ClassLoader) = if (scanData == null) run { } else scanData.annotations
-            .also { logger.debug(Logging.LOADING, "Attempting to inject @EventBusSubscriber classes into the eventbus for ${mod.modId}") }
-            .filter { it.annotationType == FORGE_SUBSCRIBER && shouldBeRegistered(mod.modId, it) }
-            .forEach { ad ->
-                val busTarget = (ad.annotationData["bus"] as? ModAnnotation.EnumHolder)
-                        ?.let { Mod.EventBusSubscriber.Bus.valueOf(it.value) }
-                        ?: Mod.EventBusSubscriber.Bus.FORGE
+fun injectSubscribers(mod: ModContainer, scanData: ModFileScanData?, loader: ClassLoader) = if (scanData == null) run { } else scanData.annotations
+        .also { logger.debug(Logging.LOADING, "Attempting to inject @EventBusSubscriber classes into the eventbus for ${mod.modId}") }
+        .filter { it.annotationType == FORGE_SUBSCRIBER && shouldBeRegistered(mod.modId, it) }
+        .forEach { ad ->
+            val busTarget = (ad.annotationData["bus"] as? ModAnnotation.EnumHolder)
+                    ?.let { Mod.EventBusSubscriber.Bus.valueOf(it.value) }
+                    ?: Mod.EventBusSubscriber.Bus.FORGE
 
-                try {
-                    logger.debug(Logging.LOADING, "Auto-subscribing ${ad.classType.className} to $busTarget")
-                    val clazz = Class.forName(ad.classType.className, true, loader)
-                    (if (busTarget == Mod.EventBusSubscriber.Bus.MOD) FMLKotlinModLoadingContext.get().modEventBus else MinecraftForge.EVENT_BUS)
-                            .register(clazz.kotlin.objectInstance ?: clazz)
-                } catch (e: ClassNotFoundException) {
-                    logger.fatal(Logging.LOADING, "Failed to load mod class ${ad.classType} for @EventBusSubscriber annotation", e)
-                    throw e
-                }
+            try {
+                logger.debug(Logging.LOADING, "Auto-subscribing ${ad.classType.className} to $busTarget")
+                val clazz = Class.forName(ad.classType.className, true, loader)
+                (if (busTarget == Mod.EventBusSubscriber.Bus.MOD) modLoadingContext.modEventBus else MinecraftForge.EVENT_BUS)
+                        .register(clazz.kotlin.objectInstance ?: clazz)
+            } catch (e: ClassNotFoundException) {
+                logger.fatal(Logging.LOADING, "Failed to load mod class ${ad.classType} for @EventBusSubscriber annotation", e)
+                throw e
             }
+        }
 
-    private fun shouldBeRegistered(modId: String, ad: ModFileScanData.AnnotationData): Boolean {
-        @Suppress("UNCHECKED_CAST")
-        val sides = (ad.annotationData["value"] as? List<ModAnnotation.EnumHolder>)
-                ?.map { Dist.valueOf(it.value) }
-                ?: listOf(Dist.CLIENT, Dist.DEDICATED_SERVER)
+private fun shouldBeRegistered(modId: String, ad: ModFileScanData.AnnotationData): Boolean {
+    @Suppress("UNCHECKED_CAST")
+    val sides = (ad.annotationData["value"] as? List<ModAnnotation.EnumHolder>)
+            ?.map { Dist.valueOf(it.value) }
+            ?: listOf(Dist.CLIENT, Dist.DEDICATED_SERVER)
 
-        val annotationModId = ad.annotationData.getOrDefault("modid", modId) as String
+    val annotationModId = ad.annotationData.getOrDefault("modid", modId) as String
 
-        return modId == annotationModId && FMLEnvironment.dist in sides
-    }
+    return modId == annotationModId && FMLEnvironment.dist in sides
 }

--- a/src/test/kotlin/net/alexwells/kottle/KottleTest.kt
+++ b/src/test/kotlin/net/alexwells/kottle/KottleTest.kt
@@ -14,15 +14,15 @@ object KottleTest {
 
     init {
         // You either need to specify generic type explicitly and use a consumer
-        FMLKotlinModLoadingContext.get().modEventBus.addListener<FMLCommonSetupEvent> { setup(it) }
+        modLoadingContext.modEventBus.addListener<FMLCommonSetupEvent> { setup(it) }
         // use a consumer with parameter types specified
-        FMLKotlinModLoadingContext.get().modEventBus.addListener { event: FMLCommonSetupEvent -> setup2(event) }
+        modLoadingContext.modEventBus.addListener<FMLCommonSetupEvent> { setup2(it) }
         // or just register whole object and mark needed method with SubscribeEvent annotations.
-        FMLKotlinModLoadingContext.get().modEventBus.register(this)
+        modLoadingContext.modEventBus.register(this)
 
-        FMLKotlinModLoadingContext.get().modEventBus.register(ObjectStub)
+        modLoadingContext.modEventBus.register(ObjectStub)
 
-        FMLKotlinModLoadingContext.get().modEventBus.addListener { event: RegistryEvent.Register<Item> -> AnotherObjectStub.registerItems(event) }
+        modLoadingContext.modEventBus.addListener<RegistryEvent.Register<Item>> { AnotherObjectStub.registerItems(it) }
     }
 
     // You can also use EventBusSubscriber as usual


### PR DESCRIPTION
This PR removes the unnecessary `FMLKotlinModLoadingContext ` and `KotlinAutomaticEventSubscriber ` objects and puts their methods in the file scope. As I now know, it's quite pointless and slightly inefficient using objects as namespaces in Kotlin. This additionally makes accessing the mod loading context much shorter.

This PR additionally replaces `getModId()` in string interpolation with the equivalent, but shorter `modId`, and fixes a slight inconsistency in the tests.